### PR TITLE
Unify up python source and binary packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
 recursive-include data *
+recursive-include src *
+recursive-include include *
+recursive-include libmei *

--- a/verovio/__init__.py
+++ b/verovio/__init__.py
@@ -1,0 +1,5 @@
+from pkg_resources import resource_filename
+
+from .verovio import *
+
+verovio.setDefaultResourcePath(resource_filename('verovio', 'data'))


### PR DESCRIPTION
- Install all required sources when building sdist
- Generate git hash before packaging sdist or building bdist
- Install data files in a subpackage of the verovio package
- Automatically set the resource path when importing verovio

There are still a few improvements that could be made, I can think of the following:
* see if we can move the `verovio` directory into `packaging/python/verovio` to prevent more directories in the source root
* refactor the command classes to remove the duplicated code when generating the git hash
* Work out a way to automatically find data directories for `packages` and `package_data` instead of explicitly writing each one
* setuptools `check` command complains that the data subdirectores aren't python modules (they don't have `__init__.py`). This doesn't seem to cause any problems, and doesn't really make sense with how we load the data, but could be worth looking into
* Test on windows